### PR TITLE
Update build_detect_platform

### DIFF
--- a/src/leveldb/build_detect_platform
+++ b/src/leveldb/build_detect_platform
@@ -1,3 +1,4 @@
+# Fix permissions to allow for execution. Remove this line after correcting file. FEB 17, 2015
 #!/bin/sh
 #
 # Detects OS we're compiling on and outputs a file specified by the first


### PR DESCRIPTION
Need to change permissions to allow execution. Prevents the makefile.unix from building FEB 17, 2015

Might need to replace file after fixing permissions.
